### PR TITLE
Validate requirements only on a single Python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,11 @@ references:
     executor:
       name: python
       version: << parameters.version >>
+  python-target-version-only-matrix: &python-target-version-only-matrix
+    matrix:
+      parameters:
+        # Expected runtime is on Python 3.9
+        version: ["3.9"]
   python-top-and-bottom-version-matrix: &python-top-and-bottom-version-matrix
     matrix:
       parameters:
@@ -103,4 +108,4 @@ workflows:
       - typecheck:
           <<: *python-top-and-bottom-version-matrix
       - check-requirements:
-          <<: *python-top-and-bottom-version-matrix
+          <<: *python-target-version-only-matrix

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ discord==1.0.1            # via -r requirements.in
 idna==2.10                # via yarl
 multidict==4.7.6          # via aiohttp, yarl
 python-dotenv==0.15.0     # via -r requirements.in
-typing-extensions==3.7.4.3  # via yarl
 yarl==1.5.1               # via aiohttp

--- a/script/requirements.txt
+++ b/script/requirements.txt
@@ -21,7 +21,6 @@ flake8-todo==0.7          # via -r script/requirements.in
 flake8-tuple==0.4.1       # via -r script/requirements.in
 flake8==3.8.4             # via -r script/requirements.in, flake8-builtins, flake8-commas, flake8-comprehensions, flake8-debugger, flake8-isort, flake8-mutable, flake8-tuple
 idna==2.10                # via -r script/../requirements.txt, yarl
-importlib-metadata==2.0.0  # via flake8, flake8-comprehensions
 isort==5.6.4              # via flake8-isort
 mccabe==0.6.1             # via flake8
 multidict==4.7.6          # via -r script/../requirements.txt, aiohttp, yarl
@@ -34,9 +33,8 @@ python-dotenv==0.15.0     # via -r script/../requirements.txt
 six==1.15.0               # via flake8-tuple, pip-tools
 testfixtures==6.15.0      # via flake8-isort
 typed-ast==1.4.1          # via mypy
-typing-extensions==3.7.4.3  # via -r script/../requirements.txt, mypy, yarl
+typing-extensions==3.7.4.3  # via mypy
 yarl==1.5.1               # via -r script/../requirements.txt, aiohttp
-zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
The requirements of packages can change between Python versions, so the output of pip-compile is therefore expectedly unstable when computed on multiple versions. Validate only on a single version (choosing the version we expect to run on) to ensure test stability.